### PR TITLE
Illumina adapter trimming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LDFLAGS=
 endif
 
 ## Source code files, add new files to this list
-SRC_COMMON  = src/base_quality.cpp src/error.cpp src/region.cpp src/stringops.cpp src/zalgorithm.cpp src/alignment_filters.cpp src/extract_indels.cpp src/mathops.cpp src/pcr_duplicates.cpp src/bam_io.cpp
+SRC_COMMON  = src/base_quality.cpp src/error.cpp src/region.cpp src/stringops.cpp src/zalgorithm.cpp src/alignment_filters.cpp src/extract_indels.cpp src/mathops.cpp src/pcr_duplicates.cpp src/bam_io.cpp src/adapter_trimmer.cpp
 SRC_HIPSTR  = src/hipstr_main.cpp src/bam_processor.cpp src/stutter_model.cpp src/snp_phasing_quality.cpp src/snp_tree.cpp src/em_stutter_genotyper.cpp src/seq_stutter_genotyper.cpp src/snp_bam_processor.cpp src/genotyper_bam_processor.cpp src/vcf_input.cpp src/read_pooler.cpp src/version.cpp src/haplotype_tracker.cpp src/pedigree.cpp src/vcf_reader.cpp src/genotyper.cpp src/directed_graph.cpp src/debruijn_graph.cpp src/fasta_reader.cpp src/vcf_writer.cpp
 SRC_SEQALN  = src/SeqAlignment/HapAligner.cpp src/SeqAlignment/AlignmentModel.cpp src/SeqAlignment/AlignmentOps.cpp src/SeqAlignment/HapBlock.cpp src/SeqAlignment/NeedlemanWunsch.cpp src/SeqAlignment/Haplotype.cpp src/SeqAlignment/HaplotypeGenerator.cpp src/SeqAlignment/HTMLCreator.cpp src/SeqAlignment/AlignmentViz.cpp src/SeqAlignment/AlignmentTraceback.cpp src/SeqAlignment/StutterAlignerClass.cpp
 SRC_DENOVO  = src/denovos/denovo_main.cpp src/error.cpp src/stringops.cpp src/version.cpp src/pedigree.cpp src/haplotype_tracker.cpp src/vcf_input.cpp src/denovos/denovo_scanner.cpp src/mathops.cpp src/vcf_reader.cpp src/denovos/denovo_allele_priors.cpp src/denovos/trio_denovo_scanner.cpp

--- a/src/adapter_trimmer.cpp
+++ b/src/adapter_trimmer.cpp
@@ -177,9 +177,9 @@ std::string AdapterTrimmer::get_trimming_stats_msg(){
   std::stringstream msg;
   msg << std::setprecision(2) << "Adapter trimming removed" << "\n"
       << "\t" << locus_r1_trimmed_bases_ << " likely adapter bases from "
-      << locus_r1_trimmed_reads_ << "/" << locus_r1_total_reads_ << " R1 reads (" << 100.0*locus_r1_trimmed_reads_/locus_r1_total_reads_ << "%)" << "\n"
+      << locus_r1_trimmed_reads_ << "/" << locus_r1_total_reads_ << " R1 reads (" << (locus_r1_total_reads_ == 0 ? 0 : 100.0*locus_r1_trimmed_reads_/locus_r1_total_reads_) << "%)" << "\n"
       << "\t" << locus_r2_trimmed_bases_ << " likely adapter bases from "
-      << locus_r2_trimmed_reads_ << "/" << locus_r2_total_reads_ << " R2 reads (" << 100.0*locus_r2_trimmed_reads_/locus_r2_total_reads_ << "%)";;
+      << locus_r2_trimmed_reads_ << "/" << locus_r2_total_reads_ << " R2 reads (" << (locus_r2_total_reads_ == 0 ? 0 : 100.0*locus_r2_trimmed_reads_/locus_r2_total_reads_) << "%)";
   return msg.str();
 }
 

--- a/src/adapter_trimmer.cpp
+++ b/src/adapter_trimmer.cpp
@@ -144,6 +144,8 @@ void AdapterTrimmer::trim_adapters(BamAlignment& aln){
   // In case trimming isn't actually desired, do nothing
   if (!trim_) return;
 
+  if (aln.Length() == 0) return;
+
   double start_time = clock(); // Start the clock
   int64_t num_trim;
   if (aln.IsFirstMate()){

--- a/src/adapter_trimmer.cpp
+++ b/src/adapter_trimmer.cpp
@@ -67,7 +67,7 @@ int64_t AdapterTrimmer::trim_five_prime(BamAlignment& aln, const std::vector<std
 
       // Check if a full match or 1 mismatch configuration exists      
       bool valid = (suffix_matches_internal[index] == max_match);
-      if (!valid){
+      if (!valid && 1.0/max_match < MAX_ERROR_RATE){
 	if (max_match < adapter_length) // Adapter left-side overhang
 	  valid = ((suffix_matches_internal[index] + 1 + prefix_matches_external[adapter_length-max_match]) == max_match);
 	else // Adapter fully inside of read sequence
@@ -112,7 +112,7 @@ int64_t AdapterTrimmer::trim_three_prime(BamAlignment& aln, const std::vector<st
 
       // Check if a full match or 1 mismatch configuration exists
       bool valid = (prefix_matches_internal[index] == max_match);
-      if (!valid){
+      if (!valid && 1.0/max_match < MAX_ERROR_RATE){
 	if (max_match < adapter_length) // Adapter right-side overhang
 	  valid = ((prefix_matches_internal[index] + 1 + suffix_matches_external[max_match-1]) == max_match);
 	else // Adapter fully inside of read sequence
@@ -165,8 +165,8 @@ void AdapterTrimmer::trim_adapters(BamAlignment& aln){
   locus_trimming_time_ += (clock() - start_time)/CLOCKS_PER_SEC; // Turn off the clock
 }
 
-// Minimum overlap between the alignment sequence and adapter sequence
-const int AdapterTrimmer::MIN_OVERLAP = 5;
+const int AdapterTrimmer::MIN_OVERLAP = 5;          // Minimum overlap between the alignment sequence and adapter sequence
+const double AdapterTrimmer::MAX_ERROR_RATE = 0.15; // Only trim if # mismatches/#overlapping bases is below this fraction
 
 // Initialize various commonly used adapter sequences. 
 // Don't use the full sequences as we only allow for 1 mismatch

--- a/src/adapter_trimmer.h
+++ b/src/adapter_trimmer.h
@@ -49,7 +49,8 @@ class AdapterTrimmer {
   
  public:
   // Minimum overlap between the adapter sequence and the read sequence for trimming to be considered
-  const static int MIN_OVERLAP;
+  const static int    MIN_OVERLAP;
+  const static double MAX_ERROR_RATE;
 
   // Commonly used Illumina adapter pairs (see https://support.illumina.com/bulletins/2016/12/what-sequences-do-i-use-for-adapter-trimming.html)
   // i)  Applicable to most WGS experiments

--- a/src/adapter_trimmer.h
+++ b/src/adapter_trimmer.h
@@ -13,9 +13,13 @@ class AdapterTrimmer {
   bool trim_; // True iff trimming should even be performed
 
   // Counters to track trimming statistics
-  int64_t r1_trimmed_bases_, r2_trimmed_bases_;
-  int64_t r1_trimmed_reads_, r2_trimmed_reads_;
-  int64_t r1_total_reads_,   r2_total_reads_;
+  int64_t locus_r1_trimmed_bases_, locus_r2_trimmed_bases_;
+  int64_t locus_r1_trimmed_reads_, locus_r2_trimmed_reads_;
+  int64_t locus_r1_total_reads_,   locus_r2_total_reads_;
+
+  int64_t total_r1_trimmed_bases_, total_r2_trimmed_bases_;
+  int64_t total_r1_trimmed_reads_, total_r2_trimmed_reads_;
+  int64_t total_r1_total_reads_,   total_r2_total_reads_;
 
   // Variables to track trimming timing
   double locus_trimming_time_;
@@ -77,11 +81,23 @@ class AdapterTrimmer {
     init();
   }
   
-  /* Save the current locus' timing info and make room for the next locus */
+  /* Save the current locus' statistics and make room for the next locus */
   void mark_new_locus(){
-    total_trimming_time_ += locus_trimming_time_;
-    locus_trimming_time_  = 0;
+    total_r1_trimmed_bases_ += locus_r1_trimmed_bases_;
+    total_r2_trimmed_bases_ += locus_r2_trimmed_bases_;
+    total_r1_trimmed_reads_ += locus_r1_trimmed_reads_;
+    total_r2_trimmed_reads_ += locus_r2_trimmed_reads_;
+    total_r1_total_reads_   += locus_r1_total_reads_;
+    total_r2_total_reads_   += locus_r2_total_reads_;
+    locus_r1_trimmed_bases_  = locus_r2_trimmed_bases_ = 0;
+    locus_r1_trimmed_reads_  = locus_r2_trimmed_reads_ = 0;
+    locus_r1_total_reads_    = locus_r2_total_reads_   = 0;
+
+    total_trimming_time_    += locus_trimming_time_;
+    locus_trimming_time_     = 0;
   }
+
+  std::string get_trimming_stats_msg();
 
   double locus_trimming_time(){ return locus_trimming_time_; }
   double total_trimming_time(){ return total_trimming_time_; }

--- a/src/bam_processor.cpp
+++ b/src/bam_processor.cpp
@@ -245,8 +245,9 @@ void BamProcessor::read_and_filter_reads(BamCramMultiReader& reader, const std::
 
       // Apply adapter trimming
       adapter_trimmer_.trim_adapters(alignment);
-      if (alignment.Length() == 0)
-	continue;
+
+      if (alignment.CigarData().size() == 0 || alignment.Length() == 0)
+        continue;
     }
 
     // Clear out mate alignment cache if we've switched to a new file to reduce memory usage

--- a/src/bam_processor.cpp
+++ b/src/bam_processor.cpp
@@ -263,7 +263,7 @@ void BamProcessor::read_and_filter_reads(BamCramMultiReader& reader, const std::
     // Only apply tests to putative STR reads that overlap the STR region
     if (alignment.Position() < region_group.stop() && alignment.GetEndPosition() >= region_group.start()){
       bool pass_one = false; // Denotes if read passed first set of simpler filters
-      std::string pass_two(regions.size(), '0'); // Denotes if read passed sceond set of additional filters for each region
+      std::string pass_two(regions.size(), '0'); // Denotes if read passed second set of additional filters for each region
                                                  // Meant to signify if reads that pass first set should be used to generate haplotypes
       std::string filter = "";
       read_count++;
@@ -439,8 +439,9 @@ void BamProcessor::read_and_filter_reads(BamCramMultiReader& reader, const std::
       write_filtered_alignment(aln_iter->second, filter, filt_writer);
   }
   potential_strs.clear(); potential_mates.clear();
-  
-  selective_logger() << read_count << " reads overlapped region, of which "
+
+  selective_logger() << adapter_trimmer_.get_trimming_stats_msg() << "\n"
+		     << read_count << " reads overlapped region, of which "
 		     << "\n\t" << hard_clip      << " were hard clipped"
 		     << "\n\t" << read_has_N     << " had an 'N' base call"
 		     << "\n\t" << low_qual_score << " had low base quality scores";


### PR DESCRIPTION
I've added functionality that automatically searches for and trims common Illumina adapter sequences from the alignments prior to genotyping. The trimming accounts for the orientation of the original read, such that adapters are appropriately trimmed from the correct end of the alignment using either the original Illumina adapter sequence or its reverse complement as appropriate.

This functionality is key to improving genotyping accuracy in datasets where adapter contamination is fairly high (> 1%). In these datasets, the adapter sequences are aligned as insertions in the flanking sequences, resulting in high DFLANKINDEL counts and occasionally causing the assembly of the flanking sequences to fail.

By performing the trimming by default, HipSTR should be more robust to this fairly common sequencing artifact.